### PR TITLE
Set Sketch's color profile to sRGB

### DIFF
--- a/admin.yml
+++ b/admin.yml
@@ -206,3 +206,5 @@
     # - name: 'Sketch: Set color profile to sRGB'
     # - shell: 'defaults write {{ user_lib_prefs }}/com.bohemiancoding.sketch3 defaultColorSpace 1'
     
+    # - name: 'Sketch: Set jpeg export quality to 100 percent'
+    # - shell: 'defaults write {{ user_lib_prefs }}com.bohemiancoding.sketch3 JPGQuality -string "1.0"'

--- a/admin.yml
+++ b/admin.yml
@@ -202,3 +202,7 @@
     # - name: 'Terminal: Set default window'
     #   shell: 'defaults write {{ user_lib_prefs }}/com.apple.Terminal "Default Window Settings" -string smoke'
     #   tags: terminal
+
+    # - name: 'Sketch: Set color profile to sRGB
+    # - shell: 'defaults write {{ user_lib_prefs }}/com.bohemiancoding.sketch3 defaultColorSpace 1
+    

--- a/admin.yml
+++ b/admin.yml
@@ -203,6 +203,6 @@
     #   shell: 'defaults write {{ user_lib_prefs }}/com.apple.Terminal "Default Window Settings" -string smoke'
     #   tags: terminal
 
-    # - name: 'Sketch: Set color profile to sRGB
-    # - shell: 'defaults write {{ user_lib_prefs }}/com.bohemiancoding.sketch3 defaultColorSpace 1
+    # - name: 'Sketch: Set color profile to sRGB'
+    # - shell: 'defaults write {{ user_lib_prefs }}/com.bohemiancoding.sketch3 defaultColorSpace 1'
     


### PR DESCRIPTION
Not 100% sure I did this right (the post_tasks are commented out?), and I don't have a way to test the playbook, but the terminal command itself successfully sets Sketch's color profile to sRGB, instead of Unmanaged.